### PR TITLE
GPTクライアントの導入

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
+	github.com/sashabaranov/go-openai v1.9.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/sashabaranov/go-openai v1.9.2 h1:7//Glm9EiMBjelgmBb00yYzKYqm1jckHWWTDLahfeuQ=
+github.com/sashabaranov/go-openai v1.9.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -1,0 +1,53 @@
+package driver
+
+import (
+	"fmt"
+	"github.com/sashabaranov/go-openai"
+	"golang.org/x/net/context"
+	"math"
+	"time"
+)
+
+const retryLimit = 5
+
+type GptDriver struct {
+	*openai.Client
+}
+
+func NewGptDriver() *GptDriver {
+	return &GptDriver{
+		openai.NewClient("your token"),
+	}
+}
+
+func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse, error) {
+	// バックオフリトライ
+	retryCnt := 0.0
+	for {
+		resp, err := d.CreateChatCompletion(
+			context.Background(),
+			openai.ChatCompletionRequest{
+				Model: openai.GPT3Dot5Turbo,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleSystem,
+						Content: "",
+					},
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: input,
+					},
+				},
+			},
+		)
+		if err != nil && retryCnt < retryLimit {
+			// error チェック
+			fmt.Println(err)
+		} else {
+			return resp, nil
+		}
+		time.Sleep(time.Duration(math.Pow(2, retryCnt)) * time.Second)
+		retryCnt++
+		fmt.Println("retrying...")
+	}
+}

--- a/infrastructure/persistence/model/organization.go
+++ b/infrastructure/persistence/model/organization.go
@@ -1,0 +1,10 @@
+package model
+
+import "time"
+
+type Organization struct {
+	ID        string    `gorm:"primaryKey"`
+	Name      string    `gorm:"unique"`
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+}

--- a/infrastructure/persistence/organization.go
+++ b/infrastructure/persistence/organization.go
@@ -5,7 +5,7 @@ import (
 	"gorm.io/gorm"
 	"reportify-backend/entity"
 	"reportify-backend/infrastructure/driver"
-	"time"
+	"reportify-backend/infrastructure/persistence/model"
 )
 
 type OrganizationPersistence struct{}
@@ -14,15 +14,8 @@ func NewOrganizationPersistence() *OrganizationPersistence {
 	return &OrganizationPersistence{}
 }
 
-type Organization struct {
-	ID        string    `gorm:"primaryKey"`
-	Name      string    `gorm:"unique"`
-	CreatedAt time.Time `gorm:"autoCreateTime"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime"`
-}
-
 func (p OrganizationPersistence) GetOrganizations(ctx context.Context, limit *int, offset *int) ([]*entity.Organization, error) {
-	var records []*Organization
+	var records []*model.Organization
 	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
 	if limit != nil {
 		db = db.Limit(*limit)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ const (
 func main() {
 	// Dependency Injection
 	db := driver.NewDB()
+	gptDriver := driver.NewGptDriver()
 
 	userPersistence := persistence.NewUserPersistence()
 	organizationPersistence := persistence.NewOrganizationPersistence()
@@ -40,7 +41,11 @@ func main() {
 	app.Use(middleware.Transaction(db))
 	app.Use(middleware.Cors())
 	app.GET("/", func(ctx *gin.Context) {
-		ctx.String(http.StatusOK, "It works")
+		message, err := gptDriver.RequestMessage("test")
+		if err != nil {
+			return
+		}
+		ctx.JSON(http.StatusOK, message)
 	})
 	//org := app.Group("/organizations")
 	app.GET("/organizations", handleResponse(organizationController.GetOrganizations))


### PR DESCRIPTION
## 概要
外部パッケージを担当しているdriverにGPTクライアントを導入
バックオフリトライを導入

## 共有情報
現状`http://localhost:8080/`にGETリクエストをすればGPTクライアントが動く

## このPRでしたいこと
GPTクライアントに文章を食わせるAPI作成（検証用）
Viperで環境変数管理