### PR TITLE
日報テスト用の仮APIを作成

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+OPENAI_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+.env
 
 # Test binary, built with `go test -c`
 *.test

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   backend:
     container_name: backend
@@ -12,6 +11,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    env_file: .env
     environment:
       APP_ENV: "dev"
       DATABASE_URL: "db:db@tcp(db:3306)/db?charset=utf8&parseTime=true"
@@ -24,7 +24,7 @@ services:
       MYSQL_USER: db
       MYSQL_PASSWORD: db
       TZ: 'Asia/Tokyo'
-      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
       timeout: 5s

--- a/controller/conversation.go
+++ b/controller/conversation.go
@@ -1,0 +1,39 @@
+package controller
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+type ConversationController struct {
+	conversationUseCase ConversationUseCase
+	organizationUseCase OrganizationUseCase
+}
+
+func NewConversationController(c ConversationUseCase, o OrganizationUseCase) *ConversationController {
+	return &ConversationController{
+		conversationUseCase: c,
+		organizationUseCase: o,
+	}
+}
+
+type NewReportRequest struct {
+	Report  string `json:"report"`
+}
+
+func (c ConversationController) SubmitReport(ctx *gin.Context) (interface{}, error){
+	userID := "dfdsafdfafdfafda" //temporary
+	organizationId := "12345678"
+	var req NewReportRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		return nil, err
+	}
+	mvv, err := c.organizationUseCase.GetMVV(ctx, organizationId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.conversationUseCase.SendReport(ctx, userID, mvv, req.Report)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/controller/interfaces.go
+++ b/controller/interfaces.go
@@ -1,12 +1,19 @@
 package controller
 
 import (
-	"golang.org/x/net/context"
 	"reportify-backend/entity"
+
+	"golang.org/x/net/context"
 )
 
 type UserUseCase interface{}
 
 type OrganizationUseCase interface {
 	GetOrganizations(ctx context.Context, limit *int, offset *int) ([]*entity.Organization, error)
+	GetMVV(ctx context.Context, organizationId string) (*entity.MVV, error)
 }
+
+type ConversationUseCase interface {
+	SendReport(ctx context.Context, userID string, mvv *entity.MVV, message string) (*entity.Conversation, error)
+}
+

--- a/data/init/1_init.sql
+++ b/data/init/1_init.sql
@@ -14,3 +14,21 @@ CREATE TABLE IF NOT EXISTS organizations (
    name VARCHAR(255) NOT NULL,
    PRIMARY KEY (id)
 );
+
+CREATE TABLE IF NOT EXISTS conversations (
+   id VARCHAR(36) NOT NULL,
+   user_id VARCHAR(36) NOT NULL,
+   is_from_ai tinyint(1) NOT NULL DEFAULT '0',
+   content TEXT NOT NULL,
+   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+   PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS mvvs (
+   id VARCHAR(36) NOT NULL,
+   organization_id VARCHAR(36) NOT NULL,
+   mission VARCHAR(255) NOT NULL,
+   vison VARCHAR(255) NOT NULL,
+   value VARCHAR(255) NOT NULL,
+   PRIMARY KEY (id)
+);

--- a/data/init/2_insert.sql
+++ b/data/init/2_insert.sql
@@ -2,3 +2,5 @@ INSERT INTO users(id, full_name, email, password) VALUES ('dfdsafdfafdfafda', 'J
 
 INSERT INTO organizations(id, name) VALUES ('12345678', 'John Doe');
 INSERT INTO organizations(id, name) VALUES ('23456789', 'John Doe2');
+
+INSERT INTO mvvs(id, organization_id, mission, vison, value) VALUES ('1assdasdas', '12345678', '技術を使って世の中の課題の解決に尽力する', '最強な開発者チームとして、本質的な価値を提供する', '個人の尊重、革新と挑戦、チームと個人の成長');

--- a/entity/conversation.go
+++ b/entity/conversation.go
@@ -1,0 +1,12 @@
+package entity
+
+import "time"
+
+// just for test, for store all conversation histories
+type Conversation struct {
+	ID   string `json:"id"`
+	UserID string `json:"userId"`
+	IsFromAI bool  `json:"isFromAi"`
+	Content string  `json:"content"`
+	CreatedAt time.Time  `json:"createdAt"`
+}

--- a/entity/mvv.go
+++ b/entity/mvv.go
@@ -1,0 +1,10 @@
+package entity
+
+// for test
+type MVV struct {
+	ID   string `json:"id"`
+	OrganizationID string `json:"organizationId"`
+	Mission string `json:"mission"`
+	Vision string `json:"vision"`
+	Value string `json:"value"`
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-playground/validator/v10 v10.13.0 // indirect
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.0
+	github.com/sashabaranov/go-openai v1.9.2
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.8.12
@@ -40,7 +41,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
-	github.com/sashabaranov/go-openai v1.9.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
+	github.com/sashabaranov/go-openai v1.9.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/sashabaranov/go-openai v1.9.2 h1:7//Glm9EiMBjelgmBb00yYzKYqm1jckHWWTDLahfeuQ=
+github.com/sashabaranov/go-openai v1.9.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -15,6 +15,7 @@ type GptDriver struct {
 }
 
 func NewGptDriver() *GptDriver {
+
 	return &GptDriver{
 		openai.NewClient("your token"),
 	}

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -1,0 +1,53 @@
+package driver
+
+import (
+	"fmt"
+	"github.com/sashabaranov/go-openai"
+	"golang.org/x/net/context"
+	"math"
+	"time"
+)
+
+const retryLimit = 5
+
+type GptDriver struct {
+	*openai.Client
+}
+
+func NewGptDriver() *GptDriver {
+	return &GptDriver{
+		openai.NewClient("your token"),
+	}
+}
+
+func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse, error) {
+	// バックオフリトライ
+	retryCnt := 0.0
+	for {
+		resp, err := d.CreateChatCompletion(
+			context.Background(),
+			openai.ChatCompletionRequest{
+				Model: openai.GPT3Dot5Turbo,
+				Messages: []openai.ChatCompletionMessage{
+					{
+						Role:    openai.ChatMessageRoleSystem,
+						Content: "",
+					},
+					{
+						Role:    openai.ChatMessageRoleUser,
+						Content: input,
+					},
+				},
+			},
+		)
+		if err != nil && retryCnt < retryLimit {
+			// error チェック
+			fmt.Println(err)
+		} else {
+			return resp, nil
+		}
+		time.Sleep(time.Duration(math.Pow(2, retryCnt)) * time.Second)
+		retryCnt++
+		fmt.Println("retrying...")
+	}
+}

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"reportify-backend/entity"
 	"time"
 
 	"github.com/sashabaranov/go-openai"
@@ -26,7 +27,7 @@ func NewGptDriver() *GptDriver {
 	}
 }
 
-func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse, error) {
+func (d *GptDriver) RequestMessage(prevMessages []*entity.Conversation, message string) (openai.ChatCompletionResponse, error) {
 	// バックオフリトライ
 	retryCnt := 0
 	for {
@@ -41,7 +42,7 @@ func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse,
 					},
 					{
 						Role:    openai.ChatMessageRoleUser,
-						Content: input,
+						Content: message,
 					},
 				},
 			},

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -27,24 +27,39 @@ func NewGptDriver() *GptDriver {
 	}
 }
 
-func (d *GptDriver) RequestMessage(prevMessages []*entity.Conversation, message string) (openai.ChatCompletionResponse, error) {
+func (d *GptDriver) RequestMessage(systemPrompt string, prevMessages []*entity.Conversation, userPrompt string) (openai.ChatCompletionResponse, error) {
 	// バックオフリトライ
 	retryCnt := 0
 	for {
+		messages := []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: systemPrompt,
+			},
+		}
+		// 同じセッションの前の会話を復元する。現状この方法が一般的のようだが、計算量O(N)かかるので会話が長くなるほど遅くなるのでキャッシュとか活用したい
+		for _, v := range prevMessages {
+			if v.IsFromAI {
+				messages = append(messages, openai.ChatCompletionMessage{
+					Role:    openai.ChatMessageRoleAssistant,
+					Content: v.Content,
+				})
+			}else {
+				messages = append(messages, openai.ChatCompletionMessage{
+					Role:    openai.ChatMessageRoleUser,
+					Content: v.Content,
+				})
+			}
+		}
+		messages = append(messages, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleUser,
+			Content: userPrompt,
+		})
 		resp, err := d.CreateChatCompletion(
 			context.Background(),
 			openai.ChatCompletionRequest{
 				Model: openai.GPT3Dot5Turbo0301,
-				Messages: []openai.ChatCompletionMessage{
-					{
-						Role:    openai.ChatMessageRoleSystem,
-						Content: "",
-					},
-					{
-						Role:    openai.ChatMessageRoleUser,
-						Content: message,
-					},
-				},
+				Messages: messages,
 			},
 		)
 		if err != nil && retryCnt < retryLimit {

--- a/infrastructure/driver/gpt.go
+++ b/infrastructure/driver/gpt.go
@@ -2,33 +2,38 @@ package driver
 
 import (
 	"fmt"
+	"math"
+	"os"
+	"time"
+
 	"github.com/sashabaranov/go-openai"
 	"golang.org/x/net/context"
-	"math"
-	"time"
 )
 
 const retryLimit = 5
+
+var (
+	openAIKey = os.Getenv("OPENAI_KEY")
+)
 
 type GptDriver struct {
 	*openai.Client
 }
 
 func NewGptDriver() *GptDriver {
-
 	return &GptDriver{
-		openai.NewClient("your token"),
+		openai.NewClient(openAIKey),
 	}
 }
 
 func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse, error) {
 	// バックオフリトライ
-	retryCnt := 0.0
+	retryCnt := 0
 	for {
 		resp, err := d.CreateChatCompletion(
 			context.Background(),
 			openai.ChatCompletionRequest{
-				Model: openai.GPT3Dot5Turbo,
+				Model: openai.GPT3Dot5Turbo0301,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role:    openai.ChatMessageRoleSystem,
@@ -45,9 +50,10 @@ func (d *GptDriver) RequestMessage(input string) (openai.ChatCompletionResponse,
 			// error チェック
 			fmt.Println(err)
 		} else {
+			fmt.Println(resp.Choices[0].Message.Content)
 			return resp, nil
 		}
-		time.Sleep(time.Duration(math.Pow(2, retryCnt)) * time.Second)
+		time.Sleep(time.Duration(math.Pow(2, float64(retryCnt))) * time.Second)
 		retryCnt++
 		fmt.Println("retrying...")
 	}

--- a/infrastructure/persistence/conversation.go
+++ b/infrastructure/persistence/conversation.go
@@ -1,0 +1,83 @@
+package persistence
+
+import (
+	"reportify-backend/entity"
+	"reportify-backend/infrastructure/driver"
+	"reportify-backend/infrastructure/persistence/model"
+
+	"github.com/google/uuid"
+	"golang.org/x/net/context"
+	"gorm.io/gorm"
+)
+
+type ConversationPersistence struct {
+	GptDriver *driver.GptDriver
+}
+
+func NewConversationPersistence(GptDriver *driver.GptDriver) *ConversationPersistence {
+	return &ConversationPersistence{
+		GptDriver: GptDriver,
+	}
+}
+
+func (u *ConversationPersistence) GetPrevConversations(ctx context.Context, userID string) ([]*entity.Conversation, error) {
+	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
+	var records []*model.Conversation
+	if err :=  db.Table("conversations").Where("user_id = ?", userID).Find(&records).Error; err != nil {
+		return nil, err
+	}
+	var conversations []*entity.Conversation
+	for _, record := range records {
+		conversations = append(conversations, &entity.Conversation{
+			ID:   record.ID,
+			UserID: record.UserID,
+			IsFromAI: record.IsFromAI,
+			Content: record.Content,
+			CreatedAt: record.CreatedAt,
+		})
+	}
+	return conversations, nil
+}
+
+func (u *ConversationPersistence) SendReport(ctx context.Context, userID string,  mvv *entity.MVV, prevMessages []*entity.Conversation, message string) (*entity.Conversation, error) {
+	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
+	var result entity.Conversation
+	db.Transaction(func(tx *gorm.DB) error {
+		resp, err := u.GptDriver.RequestMessage(prevMessages, message)
+		if err != nil {
+			return err
+		}
+		u1, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+		u2, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+		conversations := []model.Conversation{
+			{
+				ID:  u1.String(),
+				UserID: userID,
+				IsFromAI: false,
+				Content: message,
+			},
+			{
+				ID:  u2.String(),
+				UserID: userID,
+				IsFromAI: true,
+				Content: resp.Choices[0].Message.Content,
+			},
+		}
+		if err := tx.Table("conversations").Create(&conversations).Error; err != nil {
+			return err
+		}
+		result = entity.Conversation{
+			UserID: userID,
+			IsFromAI: false,
+			Content: resp.Choices[0].Message.Content,
+		}
+		return nil
+	})
+	return &result, nil
+}

--- a/infrastructure/persistence/model/conversation.go
+++ b/infrastructure/persistence/model/conversation.go
@@ -1,0 +1,11 @@
+package model
+
+import "time"
+
+type Conversation struct {
+	ID   string `gorm:"primaryKey"`
+	UserID string
+	IsFromAI bool 
+	Content string
+	CreatedAt time.Time  `gorm:"autoCreateTime"`
+}

--- a/infrastructure/persistence/model/mvv.go
+++ b/infrastructure/persistence/model/mvv.go
@@ -1,0 +1,9 @@
+package model
+
+type MVV struct {
+	ID   string `json:"id"`
+	OrganizationID string
+	Mission string 
+	Vision string
+	Value string 
+}

--- a/infrastructure/persistence/model/organization.go
+++ b/infrastructure/persistence/model/organization.go
@@ -1,0 +1,10 @@
+package model
+
+import "time"
+
+type Organization struct {
+	ID        string    `gorm:"primaryKey"`
+	Name      string    `gorm:"unique"`
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+}

--- a/infrastructure/persistence/organization.go
+++ b/infrastructure/persistence/organization.go
@@ -1,11 +1,12 @@
 package persistence
 
 import (
-	"golang.org/x/net/context"
-	"gorm.io/gorm"
 	"reportify-backend/entity"
 	"reportify-backend/infrastructure/driver"
 	"reportify-backend/infrastructure/persistence/model"
+
+	"golang.org/x/net/context"
+	"gorm.io/gorm"
 )
 
 type OrganizationPersistence struct{}
@@ -34,4 +35,19 @@ func (p OrganizationPersistence) GetOrganizations(ctx context.Context, limit *in
 		})
 	}
 	return organizations, nil
+}
+
+func (p OrganizationPersistence) GetMVV(ctx context.Context, organizationId string) (*entity.MVV, error) {
+	var record model.MVV
+	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
+	if err :=  db.Table("mvvs").Where("organization_id = ?", organizationId).First(&record).Error; err != nil {
+		return nil, err
+	}
+	return &entity.MVV{
+		ID: record.ID,
+		OrganizationID: record.OrganizationID,
+		Mission: record.Mission,
+		Vision: record.Mission,
+		Value: record.Value,
+	}, nil
 }

--- a/infrastructure/persistence/organization.go
+++ b/infrastructure/persistence/organization.go
@@ -5,7 +5,7 @@ import (
 	"gorm.io/gorm"
 	"reportify-backend/entity"
 	"reportify-backend/infrastructure/driver"
-	"time"
+	"reportify-backend/infrastructure/persistence/model"
 )
 
 type OrganizationPersistence struct{}
@@ -14,15 +14,8 @@ func NewOrganizationPersistence() *OrganizationPersistence {
 	return &OrganizationPersistence{}
 }
 
-type Organization struct {
-	ID        string    `gorm:"primaryKey"`
-	Name      string    `gorm:"unique"`
-	CreatedAt time.Time `gorm:"autoCreateTime"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime"`
-}
-
 func (p OrganizationPersistence) GetOrganizations(ctx context.Context, limit *int, offset *int) ([]*entity.Organization, error) {
-	var records []*Organization
+	var records []*model.Organization
 	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
 	if limit != nil {
 		db = db.Limit(*limit)

--- a/infrastructure/persistence/organization.go
+++ b/infrastructure/persistence/organization.go
@@ -47,7 +47,7 @@ func (p OrganizationPersistence) GetMVV(ctx context.Context, organizationId stri
 		ID: record.ID,
 		OrganizationID: record.OrganizationID,
 		Mission: record.Mission,
-		Vision: record.Mission,
+		Vision: record.Vision,
 		Value: record.Value,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
-	swaggerFiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 	"log"
 	"net/http"
 	"os"
@@ -15,6 +12,10 @@ import (
 	"reportify-backend/infrastructure/middleware"
 	"reportify-backend/infrastructure/persistence"
 	"reportify-backend/usecase"
+
+	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 const (
@@ -44,7 +45,7 @@ func main() {
 	app.Use(middleware.Transaction(db))
 	app.Use(middleware.Cors())
 	app.GET("/", func(ctx *gin.Context) {
-		message, err := gptDriver.RequestMessage([]*entity.Conversation{}, "test")
+		message, err := gptDriver.RequestMessage("", []*entity.Conversation{}, "test")
 		if err != nil {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ const (
 func main() {
 	// Dependency Injection
 	db := driver.NewDB()
+	gptDriver := driver.NewGptDriver()
 
 	userPersistence := persistence.NewUserPersistence()
 	organizationPersistence := persistence.NewOrganizationPersistence()
@@ -40,7 +41,11 @@ func main() {
 	app.Use(middleware.Transaction(db))
 	app.Use(middleware.Cors())
 	app.GET("/", func(ctx *gin.Context) {
-		ctx.String(http.StatusOK, "It works")
+		message, err := gptDriver.RequestMessage("test")
+		if err != nil {
+			return
+		}
+		ctx.JSON(http.StatusOK, message)
 	})
 	//org := app.Group("/organizations")
 	app.GET("/organizations", handleResponse(organizationController.GetOrganizations))

--- a/usecase/conversation.go
+++ b/usecase/conversation.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"reportify-backend/entity"
+
+	"golang.org/x/net/context"
+)
+
+type ConversationUseCase struct {
+	ConversationRepo
+}
+
+func NewConversationUseCase(conversationRepo ConversationRepo) *ConversationUseCase {
+	return &ConversationUseCase{
+		ConversationRepo: conversationRepo,
+	}
+}
+
+func(u *ConversationUseCase) SendReport(ctx context.Context, userID string, mvv *entity.MVV, message string) (*entity.Conversation, error){
+	prevMessages, err := u.ConversationRepo.GetPrevConversations(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return u.ConversationRepo.SendReport(ctx, userID, mvv, prevMessages, message)
+}

--- a/usecase/interfaces.go
+++ b/usecase/interfaces.go
@@ -1,12 +1,19 @@
 package usecase
 
 import (
-	"golang.org/x/net/context"
 	"reportify-backend/entity"
+
+	"golang.org/x/net/context"
 )
 
 type UserRepo interface{}
 
 type OrganizationRepo interface {
 	GetOrganizations(ctx context.Context, limit *int, offset *int) ([]*entity.Organization, error)
+	GetMVV(ctx context.Context, organizationId string) (*entity.MVV, error)
+}
+
+type ConversationRepo interface {
+	GetPrevConversations(ctx context.Context, userID string) ([]*entity.Conversation, error)
+	SendReport(ctx context.Context, userID string, mvv *entity.MVV, prevMessages []*entity.Conversation, message string) (*entity.Conversation, error)
 }

--- a/usecase/organization.go
+++ b/usecase/organization.go
@@ -16,3 +16,7 @@ func NewOrganizationUseCase(organizationRepo OrganizationRepo) *OrganizationUseC
 func (u *OrganizationUseCase) GetOrganizations(ctx context.Context, limit *int, offset *int) ([]*entity.Organization, error) {
 	return u.OrganizationRepo.GetOrganizations(ctx, limit, offset)
 }
+
+func (u *OrganizationUseCase) GetMVV(ctx context.Context, organizationId string) (*entity.MVV, error) {
+	return u.OrganizationRepo.GetMVV(ctx, organizationId)
+}


### PR DESCRIPTION
## やったこと
- 仮で会話履歴とMVVを保存する為のテーブルを作成
- 会話履歴の取得、MVVの取得、レポートの作成→フィードバック→保存を行うRepository、Usecaseの作成
- GPTをメンターに化けさせるPromptの作成
- 仮データの作成
- gpt driverのシステムプロンプト、過去の会話の引き継ぎ機能の実装

## やってないこと
- 諸々リファクタリング
- プロンプトとモデルのチューニング
- DB設計とJSON形式のすり合わせ

## OpenAI API関連の調査引き継ぎ
参考: https://zenn.dev/ryo_kawamata/articles/56ea2484320def

### Prompt Roleの違い
- System: GPTをどういうロールプレーをしてほしいのか、AI管理者としての指令
　- サービスとしてAIは主にどういう動きをするべきのか、そのフレームワークをここで定める
- Assistant: GPT自身を表す
- User: GPTベースのサービスを使用するユーザーからの指令

### 過去の会話の引き継ぎ方法
まず、過去の会話履歴をサービス側で永続しなければならない。その上で、過去の会話から続けたい場合は、対象の会話データを取り出し、CompletionのRequestに入れれば、会話を再開できる。この場合、AssistantとUserはそれぞれGPTとユーザーを表すので、AssistantとUserの履歴が交互に混ざる。そして、Systemは常にRequestの一番上に出る。よって、リクエストのプロンプトは下記のようになる。
```json
[
{"system","..."},
{"user","..."},
{"assistant","..."},
{"user","..."},
{"assistant","..."},
...
{"user","..."},
{"assistant","..."}
]
```
現状この方法が一般的だが、この方法は計算量がやばいのと、履歴が溜まるほどプロンプトが肥大化するので、サービス品質低下とトークン消費の増加を抑制する施策が必要そう。よくある対策として、過去の履歴の整理と要約を行うことによってプロンプトを減らす方向が推奨されている模様。キャッシュを使うなどインフラ側でもなんらかの対策も使えるかも？

## 検証の仕方
日報のフォーマットはプロンプトを参照。

下記の形式で`/report`にPOSTすれば良い。
```
{
    "report": "# 日報 2023-05-02\n\n## 今日やったこと\n- インバスケット研修\n- Go研修\n\n## 学んだこと、感じたこと\n- インバスケット研修でリアルの課題の解決に挑戦しましたが、限られた時間で問題を正確に解ききることはできず、自分自身はまだ実際のトラベルへの対応力は圧倒的に足りないことに気づきました\n- 元々Goの経験はあったのですが、チームワークではgoroutineに詰まってしまったので、本質的な部分の理解はまだ足りないことに気づきました\n\n## 明日やること\n- MySQL研修\n- CS研修\n- 自己理解研修\n"
}
```

**命名とアーキテクチャがだいぶまずかったらプロンプトとDriverの部分だけ参考にして、こっちをCloseしても構いません**