### PR TITLE
GormがGetOrganizationUserのクエリで余計な条件を加える問題の修正

### DIFF
--- a/infrastructure/persistence/user.go
+++ b/infrastructure/persistence/user.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -52,12 +53,13 @@ func (p UserPersistence) GetUsers(ctx context.Context, organizationID string) ([
 func (p UserPersistence) GetOrganizationUser(ctx context.Context, organizationCode string, userID string) (*entity.OrganizationUser, error) {
 	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
 	var record *model.OrganizationUser
-	if err := db.Where("user_id = ?", userID).Preload("User").Preload("Organization", "code = ?", organizationCode).First(&record).Error; err != nil {
+	if err := db.Debug().Joins("User").Joins("Organization").First(&record, "user_id = ? AND code = ?", userID, organizationCode).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, entity.NewError(http.StatusNotFound, err)
 		}
 		return nil, err
 	}
+	fmt.Println(record)
 	if record.Organization == nil {
 		return nil, entity.NewError(http.StatusNotFound, errors.New("organization not found"))
 	}

--- a/infrastructure/persistence/user.go
+++ b/infrastructure/persistence/user.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -53,13 +52,12 @@ func (p UserPersistence) GetUsers(ctx context.Context, organizationID string) ([
 func (p UserPersistence) GetOrganizationUser(ctx context.Context, organizationCode string, userID string) (*entity.OrganizationUser, error) {
 	db, _ := ctx.Value(driver.TxKey).(*gorm.DB)
 	var record *model.OrganizationUser
-	if err := db.Debug().Joins("User").Joins("Organization").First(&record, "user_id = ? AND code = ?", userID, organizationCode).Error; err != nil {
+	if err := db.Joins("User").Joins("Organization").First(&record, "user_id = ? AND code = ?", userID, organizationCode).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, entity.NewError(http.StatusNotFound, err)
 		}
 		return nil, err
 	}
-	fmt.Println(record)
 	if record.Organization == nil {
 		return nil, entity.NewError(http.StatusNotFound, errors.New("organization not found"))
 	}


### PR DESCRIPTION
![image](https://github.com/fy23-gw-gackathon/reportify-backend/assets/38996546/88c28727-bb51-4d37-8205-e0a843dd9436)
GormはこのようにPreload時にorganizations.idを指定していないのに、organizations.id=[organizationsテーブル最初のレコードのid]をAND条件で加えるので、これによって正しい結果が得られず組織の切り替えがうまくいかない

対策として、Preloadの代わりに、Joinsで条件をまとめて1つのクエリでデータを全部とってくるように修正